### PR TITLE
Clarify width of Gaussian in Z2 searches

### DIFF
--- a/tex/stingraypaper.tex
+++ b/tex/stingraypaper.tex
@@ -678,7 +678,7 @@ $\mathcal{S}$ is the summed squared error of the actual pulsed profile with resp
 
 If there is no pulsation, $\mathcal{S}$ will assume a random value distributed around the number of degrees of freedom $n - 1$ (where $n$ is the number of bins in the profile) with a well defined statistical distribution ($\chi^2_{n - 1}$) that allows an easy calculation of detection limits. 
 When observing a peak of given height is very unlikely under the null hypothesis (meaning that the probability to obtained this peak by noise is below a certain $\epsilon$), this peak is considered a pulse candidate.
-If the frequency resolution is sufficiently high, close to the correct frequency, as described by \citet{leahy1983b} and \citet{leahy1987}, the peak in the epoch folding periodogram has the shape of a $\mathrm{sinc}^2$ function whose width is driven by the length of the observation.
+If the frequency resolution is sufficiently high, close to the correct frequency, as described by \citet{leahy1983b} and \citet{leahy1987}, the peak in the epoch folding periodogram has the shape of a $\mathrm{sinc}^2$ function whose width is driven by the length $T$ of the observation (FWHM $\Delta \nu\sim0.9/T$).
 
 The epoch folding statistic, however, can give the same value for a pulse profile at the correct frequency and, for example, a harmonic that produces a deviation from a Poisson distribution.
 A more effective method is the $Z^2_n$ statistics \citep{buccheri1983}, which is conceptually similar to EF but has high values when the signal is well described by a small number of sinusoidal harmonics: 
@@ -707,7 +707,7 @@ We recommend in the documentation to use a number of bins at least 10 times larg
 \subsection{Characterization of pulsar behavior}
 \label{sec:ephem}
 As seen in Section~\ref{sec:efzsq}, the \zsq or the EF periodograms of a perfectly stable pulsation have the shape of a $\mathrm{sinc}^2$ function.
-\stingray has functionality to fit these periodograms with a $\mathrm{sinc}^2$ funtion or alternatively a Gaussian model, and find the mean frequency with high precision.
+\stingray has functionality to fit these periodograms with a $\mathrm{sinc}^2$ function or alternatively a Gaussian model, and find the mean frequency with high precision\footnote{When using the Gaussian model, the width of the impulse is similar to the  FWHM $\Delta \nu\sim0.9/T$ of the  $\mathrm{sinc}^2$ function (Section \ref{sec:sec:efza}). It does \textit{not} represent an errorbar to the frequency measurement.}.
 
 A significant deviation from the expected shape from these models can happen if the pulsation is not stable.
 Calculating the \textit{phaseogram} (Figure~\ref{fig:phaseogram}) is an option to investigate how the pulse phase varies in time.


### PR DESCRIPTION
Very minor changes to clarify that the Gaussian width is not an error bar on the measurement, but it's driven by the observation length.